### PR TITLE
For 16-bit Windows, force __doserror_ symbol as near intra-segment symbol and call to preserve CF flag in real-mode

### DIFF
--- a/bld/clib/_dos/a/error086.asm
+++ b/bld/clib/_dos/a/error086.asm
@@ -40,7 +40,11 @@ include struct.inc
 
         xdefp   __doserror_
 ;
+ifdef __WINDOWS__
+        defpnear __doserror_
+else
         defp    __doserror_
+endif
         _if     c               ; if error
           push  AX              ; - save return code
           call  __set_errno_dos ; - set errno
@@ -53,7 +57,11 @@ include struct.inc
 
         xdefp   __doserror1_
 ;
+ifdef __WINDOWS__
+        defpnear __doserror1_
+else
         defp    __doserror1_
+endif
         _if     c               ; if error
           call  __set_errno_dos ; - set errno, return -1
         _else                   ; else

--- a/bld/clib/h/doserror.h
+++ b/bld/clib/h/doserror.h
@@ -32,10 +32,22 @@
 #ifndef _DOSERROR_H_INCLUDED
 #define _DOSERROR_H_INCLUDED
 
+#if (defined(__MEDIUM__) || defined(__LARGE__) || defined(__HUGE__)) && defined(__WINDOWS__) /* 16-bit Windows only */
+
+extern unsigned __near __doserror_( unsigned );
+#pragma aux __doserror_ "*" __parm __caller __near
+
+extern unsigned __near __doserror1_( unsigned );
+#pragma aux __doserror1_ "*" __parm __caller __near
+
+#else
+
 extern unsigned __doserror_( unsigned );
 #pragma aux __doserror_ "*" __parm __caller
 
 extern unsigned __doserror1_( unsigned );
 #pragma aux __doserror1_ "*" __parm __caller
+
+#endif
 
 #endif

--- a/bld/watcom/h/mdef.inc
+++ b/bld/watcom/h/mdef.inc
@@ -133,6 +133,10 @@ defp            macro   dsym,exp
          dsym   proc    far exp
                 endm
 
+defpnear        macro   dsym,exp
+         dsym   proc    near exp
+                endm
+
 defpe           macro   dsym
                 ifdef _EXPORT
          dsym   proc    far export
@@ -230,6 +234,10 @@ defn            macro   dsym
                 endm
 
 defp            macro   dsym,exp
+         dsym   proc    near exp
+                endm
+
+defpnear        macro   dsym,exp
          dsym   proc    near exp
                 endm
 


### PR DESCRIPTION
Real-mode Windows, for MOVEABLE segments, redirects FAR calls through an export table entry that starts with a "SAR" instruction followed by a FAR JMP. The SAR (shift arithmetic right) is apparently how the Windows LRU algorithm determines which segments are most often used so that it can discard segments not in use, however it also corrupts the CF (carry) flag which __doserror_ needs to do it's job properly. As a near intra-segment symbol, the real-mode Windows FAR JMP and tracking is eliminated and the carry flag is preserved.